### PR TITLE
postgresql password needed for protfpd.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = git://github.com/galaxyproject/ansible-galaxy-tools.git
 [submodule "roles/galaxyprojectdotorg.galaxy-extras"]
 	path = roles/galaxyprojectdotorg.galaxy-extras
-	url = git://github.com/galaxyproject/ansible-galaxy-extras
+	url = git://github.com/mvdbeek/ansible-galaxy-extras
 [submodule "roles/natefoo.postgresql_objects"]
 	path = roles/natefoo.postgresql_objects
 	url = git://github.com/natefoo/ansible-postgresql-objects.git

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -31,6 +31,7 @@
     - role: natefoo.postgresql_objects
       postgresql_objects_users:
         - name: "{{ galaxy_user_name }}"
+          password: "{{ galaxy_user_name }}"
       postgresql_objects_databases:
         - name: "{{ galaxy_user_name }}"
           owner: "{{ galaxy_user_name }}"

--- a/hosts
+++ b/hosts
@@ -6,6 +6,7 @@ localhost ansible_ssh_user="root" ansible_ssh_private_key_file="~/.ssh/id_rsa"
 install_galaxy="True"
 install_tools="True"
 run_data_manager="True"
+proftpd_nat_masquerade=true
 #params
 supervisor_postgres_database_path="/etc/postgresql/{{ postgresql_version }}/main"
 galaxy_user_name="galaxy"

--- a/roles/artimed_extras/defaults/main.yml
+++ b/roles/artimed_extras/defaults/main.yml
@@ -13,6 +13,8 @@ encoding: "base64"
 proftpd_db_connection: "{{ galaxy_user_name }}@localhost"
 proftpd_db_username: "{{ galaxy_user_name }}"
 proftpd_db_password: "{{ galaxy_user_name }}"
+proftpd_passive_port_low: 49152
+proftpd_passive_port_high: 65534
 auth_type: "PBKDF2"
 sql_query_user: "SELECT \"email, (CASE WHEN substring(password from 1 for 6) = 'PBKDF2' THEN substring(password from 38 for 69) ELSE password END) AS password2,512,512,'{{ galaxy_ftp }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'\""
 sql_query_alt: "SELECT \"(CASE WHEN SUBSTRING (password from 1 for 6) = 'PBKDF2' THEN SUBSTRING (password from 21 for 16) END) AS salt FROM galaxy_user WHERE email='%U'\""

--- a/roles/artimed_extras/templates/proftpd.conf.j2
+++ b/roles/artimed_extras/templates/proftpd.conf.j2
@@ -15,7 +15,12 @@ User                            nobody
 Group                           nogroup
 
 # Passive port range for the firewall
-PassivePorts                    30000 40000
+PassivePorts                    {{ proftpd_passive_port_low }} {{ proftpd_passive_port_high }}
+
+# If your host was NATted, this option is useful in order to
+# allow passive tranfers to work. You have to use your public
+# address and opening the passive ports used on your firewall as well.
+MasqueradeAddress               %{env:PUBLIC_IP}
 
 # Cause every FTP user to be "jailed" (chrooted) into their home directory
 DefaultRoot                     ~


### PR DESCRIPTION
@drosofff this should - in part - fix issue #55 
in addition you may need to do [this](http://www.creativepulse.gr/en/blog/2014/how-to-install-an-ftp-server-on-an-ubuntu-based-amazon-ec2-instance)
```
Open ports 20-21 for the main FTP listening socket and a few more (1024-1048 or anything else from 1024 or higher) for passive connections. To do this go to the AWS console page (http://console.aws.amazon.com), open the EC2 service and choose "Security Groups" from the left panel. Click your active security group and then open the "Inbound" tab. Click "Edit" and add two rules of type "Custom TCP Rule". For the first one type "20-21" in the Port Range and "1024-1048" for the second. Click "Save" to save the new rules. Your EC2 instance is now allowed to listen for incoming connections at those two port ranges.
```
