### PR TITLE
Fix tool role docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,8 @@ script:
   - curl --fail $BIOBLEND_GALAXY_URL/api/version
   - time > $HOME/time.txt && curl --fail -T $HOME/time.txt ftp://localhost:8021 --user $GALAXY_USER:$GALAXY_USER_PASSWD
   - curl --fail ftp://localhost:8021 --user $GALAXY_USER:$GALAXY_USER_PASSWD
-after_success:
-  - docker tag galaxy_kickstart artbio/galaxy-kickstart-base:$TRAVIS_COMMIT
-  - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - docker push artbio/galaxy-kickstart-base:$TRAVIS_COMMIT
+deploy:
+  provider: script
+  script: travis_wait deploy.sh
+  on:
+    branch: master

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,3 +3,4 @@ docker tag galaxy_kickstart artbio/galaxy-kickstart-base:$TRAVIS_COMMIT
 docker tag galaxy_kickstart artbio/galaxy-kickstart-base:latest
 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 docker push artbio/galaxy-kickstart-base:$TRAVIS_COMMIT
+docker push artbio/galaxy-kickstart-base:latest

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+docker tag galaxy_kickstart artbio/galaxy-kickstart-base:$TRAVIS_COMMIT
+docker tag galaxy_kickstart artbio/galaxy-kickstart-base:latest
+docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+docker push artbio/galaxy-kickstart-base:$TRAVIS_COMMIT


### PR DESCRIPTION
That should fix the tool installations that are prematurely declared as finished, and it should only push to dockerhub when on the master branch, and we increase the timeout with travis_wait.