### PR TITLE
[skip-ci] Rationalize job_conf.xml

### DIFF
--- a/extra-files/lbcd41.snv.jussieu.fr/job_conf.xml
+++ b/extra-files/lbcd41.snv.jussieu.fr/job_conf.xml
@@ -12,42 +12,15 @@
         <handler id="handler3" tags="handlers"/>
     </handlers>
     <destinations default="dynamic">
-        <destination id="cluster" runner="slurm">
-            <!-- <param id="docker_enabled">true</param> -->
-            <param id="nativeSpecification">--ntasks=8</param>
-            <param id="docker_sudo">false</param>
-            <param id="docker_volumes_from">galaxy</param>
-        </destination>
-        <destination id="cluster" runner="slurm">
-        <param id="nativeSpecification">--ntasks=8</param>
-        </destination>
-	<!-- heavy jobs (tophat) will be routed to cluster_heavy with less concurrent jobs available-->
-        <destination id="cluster_heavy" runner="slurm">
-            <param id="nativeSpecification">--ntasks=8</param>
-        </destination>
-	<!-- users with IBPS role will be routed to cluster_ibps with more concurrent jobs available-->
-        <destination id="cluster_ibps" runner="slurm">
-            <param id="nativeSpecification">--ntasks=8</param>
-        </destination>
-	<!-- users with IBPS role running heavy jobs will be routed to cluster_heavy_ibps with medium amount of concurrent jobs available-->
-        <destination id="cluster_heavy_ibps" runner="slurm">
-            <param id="nativeSpecification">--ntasks=8</param>
-        </destination>
-	<!-- the "dynamic" destination selects the static destination ("cluster" or "cluster_ibps") based on the users role-->
-        <destination id="dynamic" runner="dynamic">
-            <param id="nativeSpecification">--ntasks=8</param>
-            <param id="type">python</param>
-	    <!-- cluster is a function in lib/galaxy/jobs/rules/destinations.py. It returns either the "cluster" or "cluster_ibps" destination-->
-            <param id="function">cluster</param>
-        </destination>
-	<!-- the "dynamic_heavy" destination selects the static destination ("cluster_heavy" or "cluster_ibps_heavy") based on the users role-->
-        <destination id="dynamic_heavy" runner="dynamic">
-            <param id="nativeSpecification">--ntasks=8</param>
-            <param id="type">python</param>
-	    <!-- cluster_heavy is a function in lib/galaxy/jobs/rules/destinations.py. It returns either the "cluster_heavy" or "cluster_ibps_heavy" destination-->
-            <param id="function">cluster_heavy</param>
-            <param id="nativeSpecification">--ntasks=8</param>
-        </destination>
+	<!-- heavy jobs (tophat, cuffdiff, see tools section below) will be routed to cluster_heavy with less concurrent jobs available.
+        Based on whether a job is heavy (dynamic_heavy)  or not (dynamic), a function in lib/galaxy/jobs/rules/destinations.py will be called,
+        which returns either the cluster[_heavy] or cluster_[heavy]_ibps destination, based on whether a user belongs to the IBPS group or not. -->
+        <expand macro="cluster_dynamic" id="dynamic_heavy" function="cluster_heavy"/>
+        <expand macro="cluster_dynamic" id="dynamic" function="cluster"/>
+        <expand macro="cluster" id="cluster"/>
+        <expand macro="cluster" id="cluster_ibps"/>
+        <expand macro="cluster" id="cluster_heavy"/>
+        <expand macro="cluster" id="cluster_heavy_ibps"/>
     </destinations>
     <limits>
         <limit type="anonymous_user_concurrent_jobs">1</limit>
@@ -60,5 +33,28 @@
         <tool id="tophat2" destination="dynamic_heavy"/>
         <tool id="cuffdiff" destination="dynamic_heavy"/>
         <tool id="rna_star" destination="dynamic_heavy"/>
+        <tool id="bowtieForSmallRNA" destination="dynamic_heavy"/>
+        <tool id="bowtie2" destination="dynamic_heavy"/>
+        <tool id="hisat2" destination="dynamic_heavy"/>
+        <tool id="ncbi_blastx_wrapper" destination="dynamic_heavy"/>
+        <tool id="ncbi_blastn_wrapper" destination="dynamic_heavy"/>
+        <tool id="ncbi_blastp_wrapper" destination="dynamic_heavy"/>
    </tools>
+   <macros>
+        <xml name="cluster_dynamic" tokens="id,function">
+            <destination id="@ID@" runner="dynamic">
+               <param id="type">python</param>
+               <param id="function">@FUNCTION@</param>
+            </destination>
+        </xml>
+        <xml name="cluster" tokens="id">
+            <destination id="@ID@" runner="slurm">
+               <param id="type">python</param>
+               <param id="nativeSpecification">--ntasks=8</param>
+               <!-- <param id="docker_enabled">true</param> -->
+               <param id="docker_sudo">false</param>
+               <param id="docker_volumes_from">galaxy</param>
+            </destination>
+        </xml>
+    </macros>
 </job_conf>


### PR DESCRIPTION
Introduce ntask into each slurm cluster destination. Clarify the cluster
selection process, use macros and unify job_handler name and number between
mississippi and plastisipi.

This is how we run mississippi and plastisipi now.