### PR TITLE
Automate documentation upload to gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vagrant/
 *.retry
 .DS_Store
+docs/html

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,14 @@ dist: trusty
 
 env:
   - TOX_ENV=py27
+  global:
+    - SITE_URL: https://artbio.github.io/ansible-artimed/
+    - GH_USER_NAME: "Marius van den Beek"
+    - GH_USER_EMAIL: m.vandenbeek@gmail.com
+    - GH_REF: github.com/ARTbio/ansible-artimed.git
+    # This is a travis-encrypted github token, to allow automatic pushing of the documentation.
+    # See https://mwop.net/blog/2016-01-29-automating-gh-pages.html
+    - secure: "pseB6yOf48IPBRjuqXz+huJORBEtbaiyGnqE4NQVX0LXzNPpwaVBNURIMfvbPhZ5OhoEhnt8a0dZT95fQie0H82oQU9vJ73tBb/rNlytbtJQ4cXYOqn4HRzQsrHY1Tns5++LZmTrLWGKTGvO3bCg6nBTXSmda4kr46tEUJCI9IZRWPHIZu2MjfSMe5qxu4cT11hzQw6NuoTJs+B49uvz+0MCSP+Q3bDGHauVP6n/NjEItka1Rw75GIb+BqqKN4TQ+Wpv9+bM+WuUGdUNGDaFyR9y/M1Br6z+YfySu0OBjZuEf4bF3ZSh70W8VBm3fQW+aOZw3U9GA2FOcVERSGdMDq8UYj52T0c0d38pXCsxj51MFQ5eIlXp2tUSW/S8nttynGYWTqmUngin/qm6w6JnC+g6RLWlRhPYZfgZ/UggBu883N49OYj33hSwVlSmIspmK5KjD8t9X3LuRwbRPeNXTsHZppAEbFu/HezxxY1lK/pQepQIs5SHy1bXCMnLhQajfzrH82EiY7U/DEyYkrUPaHVBU27CmaNFA9g/l/SZaWnUq/ZQaKloQCBXoVGudrX4MWcIf4Do95WUTzZl4qc+2GhzIy9HZA9IA27zHW5FD5NhFf58ICmIkyhMlndIG3K8neRDRVn3keoh79feqOibyevSuQ8w3xaNBi4zr5eTqus="
 
 before_install:
   - export GALAXY_TRAVIS_USER=galaxy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,17 @@
 ---
+language: python
 python: "2.7"
 sudo: required
 dist: trusty
 
 env:
-  - TOX_ENV=py27
   global:
-    - SITE_URL: https://artbio.github.io/ansible-artimed/
-    - GH_USER_NAME: "Marius van den Beek"
-    - GH_USER_EMAIL: m.vandenbeek@gmail.com
-    - GH_REF: github.com/ARTbio/ansible-artimed.git
-    # This is a travis-encrypted github token, to allow automatic pushing of the documentation.
-    # See https://mwop.net/blog/2016-01-29-automating-gh-pages.html
-    - secure: "pseB6yOf48IPBRjuqXz+huJORBEtbaiyGnqE4NQVX0LXzNPpwaVBNURIMfvbPhZ5OhoEhnt8a0dZT95fQie0H82oQU9vJ73tBb/rNlytbtJQ4cXYOqn4HRzQsrHY1Tns5++LZmTrLWGKTGvO3bCg6nBTXSmda4kr46tEUJCI9IZRWPHIZu2MjfSMe5qxu4cT11hzQw6NuoTJs+B49uvz+0MCSP+Q3bDGHauVP6n/NjEItka1Rw75GIb+BqqKN4TQ+Wpv9+bM+WuUGdUNGDaFyR9y/M1Br6z+YfySu0OBjZuEf4bF3ZSh70W8VBm3fQW+aOZw3U9GA2FOcVERSGdMDq8UYj52T0c0d38pXCsxj51MFQ5eIlXp2tUSW/S8nttynGYWTqmUngin/qm6w6JnC+g6RLWlRhPYZfgZ/UggBu883N49OYj33hSwVlSmIspmK5KjD8t9X3LuRwbRPeNXTsHZppAEbFu/HezxxY1lK/pQepQIs5SHy1bXCMnLhQajfzrH82EiY7U/DEyYkrUPaHVBU27CmaNFA9g/l/SZaWnUq/ZQaKloQCBXoVGudrX4MWcIf4Do95WUTzZl4qc+2GhzIy9HZA9IA27zHW5FD5NhFf58ICmIkyhMlndIG3K8neRDRVn3keoh79feqOibyevSuQ8w3xaNBi4zr5eTqus="
+    - TOX_ENV=py27
+    - SITE_URL="https://artbio.github.io/ansible-artimed/"
+    - GH_USER_NAME="Marius van den Beek"
+    - GH_USER_EMAIL="m.vandenbeek@gmail.com"
+    - GH_REF="github.com/ARTbio/ansible-artimed.git"
+    - secure="pseB6yOf48IPBRjuqXz+huJORBEtbaiyGnqE4NQVX0LXzNPpwaVBNURIMfvbPhZ5OhoEhnt8a0dZT95fQie0H82oQU9vJ73tBb/rNlytbtJQ4cXYOqn4HRzQsrHY1Tns5++LZmTrLWGKTGvO3bCg6nBTXSmda4kr46tEUJCI9IZRWPHIZu2MjfSMe5qxu4cT11hzQw6NuoTJs+B49uvz+0MCSP+Q3bDGHauVP6n/NjEItka1Rw75GIb+BqqKN4TQ+Wpv9+bM+WuUGdUNGDaFyR9y/M1Br6z+YfySu0OBjZuEf4bF3ZSh70W8VBm3fQW+aOZw3U9GA2FOcVERSGdMDq8UYj52T0c0d38pXCsxj51MFQ5eIlXp2tUSW/S8nttynGYWTqmUngin/qm6w6JnC+g6RLWlRhPYZfgZ/UggBu883N49OYj33hSwVlSmIspmK5KjD8t9X3LuRwbRPeNXTsHZppAEbFu/HezxxY1lK/pQepQIs5SHy1bXCMnLhQajfzrH82EiY7U/DEyYkrUPaHVBU27CmaNFA9g/l/SZaWnUq/ZQaKloQCBXoVGudrX4MWcIf4Do95WUTzZl4qc+2GhzIy9HZA9IA27zHW5FD5NhFf58ICmIkyhMlndIG3K8neRDRVn3keoh79feqOibyevSuQ8w3xaNBi4zr5eTqus="
 
 before_install:
   - export GALAXY_TRAVIS_USER=galaxy

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,34 @@
 #!/usr/bin/env bash
+
+# We start by building and deploying the documentation
+SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd -P)"
+pip install --user mkdocs
+# Initialize gh-pages checkout
+mkdir -p docs/html
+(
+    cd docs/html
+    git init
+    git config user.name "${GH_USER_NAME}"
+    git config user.email "${GH_USER_EMAIL}"
+    git remote add upstream "https://${GH_TOKEN}@${GH_REF}"
+    git fetch upstream
+    git reset upstream/gh-pages
+)
+
+cd $SCRIPT_PATH
+mkdocs build --clean --site-dir docs/html
+
+# Commit and push the documentation to gh-pages
+(
+    cd docs/html
+    touch .
+    git add -A .
+    git commit -m "Rebuild pages at ${rev}"
+    git push -q upstream HEAD:gh-pages
+)
+cd $SCRIPT_PATH
+
+# Next we upload to docker
 docker tag galaxy_kickstart artbio/galaxy-kickstart-base:$TRAVIS_COMMIT
 docker tag galaxy_kickstart artbio/galaxy-kickstart-base:latest
 LOGIN="docker login -e=$DOCKER_EMAIL -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD"


### PR DESCRIPTION
Up to now we had to manually update the documentation.
 (`mkdocs gh-deploy` from the projects' root folder).

We now let travis do the job every time we merge a build into master, the same way that we already push to the dockerhub.