### PR TITLE
Persistent import postgres fix, data managers and dataset purge

### DIFF
--- a/dockerfiles/galaxy-kickstart/Dockerfile
+++ b/dockerfiles/galaxy-kickstart/Dockerfile
@@ -20,11 +20,10 @@ RUN pip install --upgrade pip && pip install ansible
 COPY  .  /setup
 WORKDIR /setup
 
-LC_ALL=en_US.UTF-8 \
+ENV LC_ALL=en_US.UTF-8 \
 LANG=en_US.UTF-8
 
 RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
-
 RUN ansible-playbook -i docker_inventory -c local galaxy.yml && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/dockerfiles/galaxy-kickstart/Dockerfile
+++ b/dockerfiles/galaxy-kickstart/Dockerfile
@@ -20,6 +20,11 @@ RUN pip install --upgrade pip && pip install ansible
 COPY  .  /setup
 WORKDIR /setup
 
+LC_ALL=en_US.UTF-8 \
+LANG=en_US.UTF-8
+
+RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
+
 RUN ansible-playbook -i docker_inventory -c local galaxy.yml && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/extra-files/metavisitor/metavisitor_tool_list.yml
+++ b/extra-files/metavisitor/metavisitor_tool_list.yml
@@ -1,122 +1,140 @@
 tools:
-- name: sra_tools
-  owner: iuc
+- name: blast_to_scaffold
+  owner: drosofff
   revisions:
-  - b723c120161a
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-  tool_panel_section_label: "Get Data"
-- name: trinityrnaseq
-  owner: anmoljh
-  revisions:
-  - 0a576a57a9eb
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+  - 3288cc5a57e5
   tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
 - name: bowtie2
   owner: devteam
   revisions:
   - a9d4f71dbfb0
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
   tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: cherry_pick_fasta
+  owner: drosofff
+  revisions:
+  - c7a0ec8263b4
+  tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: concatenate_multiple_datasets
+  owner: mvdbeek
+  revisions:
+  - 201c568972c3
+  tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: data_manager_bowtie2_index_builder
+  owner: devteam
+  revisions:
+  - e87aeff2cf88
+  tool_panel_section_label: null
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: data_manager_bowtie_index_builder
+  owner: iuc
+  revisions:
+  - 0a0c648498e2
+  tool_panel_section_label: null
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: data_manager_fetch_genome_dbkeys_all_fasta
+  owner: devteam
+  revisions:
+  - 776bb1b478a0
+  tool_panel_section_label: null
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
 - name: fasta_filter_by_length
   owner: devteam
   revisions:
   - c8cd0a03db49
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
   tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
 - name: fastq_to_fasta
   owner: devteam
   revisions:
   - 186b8d913e6c
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
   tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
 - name: fastx_trimmer
   owner: devteam
   revisions:
   - 377ac2829eac
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
   tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: fetch_fasta_from_ncbi
+  owner: drosofff
+  revisions:
+  - befdb392fece
+  tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: khmer_normalize_by_median
+  owner: iuc
+  revisions:
+  - 6d8793a4923d
+  tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: msp_blastparser_and_hits
+  owner: drosofff
+  revisions:
+  - 6dfa79a6908a
+  tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: msp_cap3
+  owner: drosofff
+  revisions:
+  - ddb463fdf57e
+  tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: msp_fasta_tabular_converter
+  owner: drosofff
+  revisions:
+  - 330dd8a8c31a
+  tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: msp_oases
+  owner: drosofff
+  revisions:
+  - f08d9c814ffb
+  tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: msp_sr_bowtie
+  owner: drosofff
+  revisions:
+  - c1bfa227bbb6
+  tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: msp_sr_readmap_and_size_histograms
+  owner: drosofff
+  revisions:
+  - 68f58363f1c6
+  tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
 - name: ncbi_blast_plus
   owner: devteam
   revisions:
   - 7f3c448e119b
   - 577d9c12411a
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
   tool_panel_section_label: Metavisitor
-- name: blast_to_scaffold
-  owner: drosofff
-  revisions:
-  - 3288cc5a57e5
   tool_shed_url: https://toolshed.g2.bx.psu.edu/
-  tool_panel_section_label: Metavisitor
-- name: cherry_pick_fasta
-  owner: drosofff
-  revisions:
-  - c7a0ec8263b4
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-  tool_panel_section_label: Metavisitor
-- name: fetch_fasta_from_ncbi
-  owner: drosofff
-  revisions:
-  - befdb392fece
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-  tool_panel_section_label: Metavisitor
-- name: msp_blastparser_and_hits
-  owner: drosofff
-  revisions:
-  - 6dfa79a6908a
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-  tool_panel_section_label: Metavisitor
-- name: msp_cap3
-  owner: drosofff
-  revisions:
-  - ddb463fdf57e
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-  tool_panel_section_label: Metavisitor
-- name: msp_fasta_tabular_converter
-  owner: drosofff
-  revisions:
-  - 330dd8a8c31a
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-  tool_panel_section_label: Metavisitor
-- name: msp_oases
-  owner: drosofff
-  revisions:
-  - f08d9c814ffb
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-  tool_panel_section_label: Metavisitor
-- name: msp_sr_bowtie
-  owner: drosofff
-  revisions:
-  - c1bfa227bbb6
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-  tool_panel_section_label: Metavisitor
-- name: msp_sr_readmap_and_size_histograms
-  owner: drosofff
-  revisions:
-  - 68f58363f1c6
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-  tool_panel_section_label: Metavisitor
-- name: yac_clipper
-  owner: drosofff
-  revisions:
-  - 91cce7c1436d
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-  tool_panel_section_label: Metavisitor
-- name: khmer_normalize_by_median
-  owner: iuc
-  revisions:
-  - 6d8793a4923d
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
-  tool_panel_section_label: Metavisitor
 - name: regex_find_replace
   owner: jjohnson
   revisions:
   - 9ea374bb0350
-  tool_shed_url: https://toolshed.g2.bx.psu.edu/
   tool_panel_section_label: Metavisitor
-- name: concatenate_multiple_datasets
-  owner: mvdbeek
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: sra_tools
+  owner: iuc
   revisions:
-  - 201c568972c3
+  - b723c120161a
+  tool_panel_section_label: Get Data
   tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: trinityrnaseq
+  owner: anmoljh
+  revisions:
+  - 0a576a57a9eb
   tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/
+- name: yac_clipper
+  owner: drosofff
+  revisions:
+  - 91cce7c1436d
+  tool_panel_section_label: Metavisitor
+  tool_shed_url: https://toolshed.g2.bx.psu.edu/

--- a/group_vars/all
+++ b/group_vars/all
@@ -48,6 +48,7 @@ galaxy_config:
     tool_dependency_dir: "{{ tool_dependency_dir }}"
     ftp_upload_dir: "{{ proftpd_files_dir }}"
     ftp_upload_site: ftp://{{ galaxy_hostname }}
+    allow_user_dataset_purge: True
     #tool_sheds_config_file: "{{ galaxy_config_dir }}/tool_sheds_conf.xml"
     #to be done only in production
     #debug: False

--- a/group_vars/all
+++ b/group_vars/all
@@ -25,6 +25,7 @@ supervisor_postgres_database_path: /etc/postgresql/{{ postgresql_version }}/main
 apt_package_state: present
 galaxy_extras_apt_package_state: present
 tool_dependency_dir: /home/{{ galaxy_user_name }}/tool_dependencies
+shed_tools_dir: "{{ galaxy_server_dir }}/../shed_tools"
 tool_data_dir: "{{ galaxy_server_dir  }}/tool-data"
 additional_files_list: []
 

--- a/roles/galaxy.movedata/defaults/main.yml
+++ b/roles/galaxy.movedata/defaults/main.yml
@@ -1,6 +1,7 @@
 galaxy_persistent_directory: /export
 galaxy_persist_directories: 
   - { path: "{{ tool_dependency_dir }}", owner: "{{ galaxy_user_name }}" }
+  - { path: "{{ shed_tools_dir }}", owner: "{{ galaxy_user_name }}" }
   - { path: "{{ tool_data_dir }}", owner: "{{ galaxy_user_name }}" }
   - { path: "{{ galaxy_config_dir }}", owner: "{{ galaxy_user_name }}" }
   - { path: "{{ galaxy_mutable_data_dir }}", owner: "{{ galaxy_user_name }}" }


### PR DESCRIPTION
- Persistent import postgres fix

- Include data managers for bowtie, bowtie2 and fasta in metavisitor tool list.
The order of the tools is slightly re-arranged (ordered alphabetically), because I used the get_tool_tool_yml_from_gi.py script on an instance where I manually installed those data managers.

- Allow users to delete files via UI

- Add ../shed_tools/ directory to list of directories that need to persist.

Closes #115 #116 #117 #118 