### PR TITLE
Set contents of /etc/default/supervisor

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -33,13 +33,13 @@
         - configure_galaxy
         - install_galaxy
 
+    - role: set_supervisor_env_vars
+
     #installs supervisor, nginx and proftpd
     - role: galaxyprojectdotorg.galaxy-extras
       tags:
         - configure_server_stack
         - install_extras
-
-    - role: set_supervisor_env_vars
 
     - role: ensure_postgresql_up
       tags:

--- a/roles/set_supervisor_env_vars/tasks/main.yml
+++ b/roles/set_supervisor_env_vars/tasks/main.yml
@@ -3,6 +3,6 @@
 # which will be sourced when starting/restarting supervisor
 
 - name: Add supervisor ENV vars
-  lineinfile: "dest=/etc/default/supervisor state=present line={{ item }}"
+  lineinfile: "dest=/etc/default/supervisor state=present create=yes line={{ item }}"
   with_items:
     - "{{ supervisor_env_vars }}"


### PR DESCRIPTION
before starting supervisor for the first time. Otherwise the supervisor process
is running without the environmental variables, and if the nat_masquerade
option is used (AWS needs this), the restart will fail.

@drosofff On already running instances you would need to do `service supervisor stop` before running the playbook again. I'm out for today, but in the future we can make sure to restart supervisor if there are any changes to the environmental variables.

Should fix #130 