### PR TITLE
Restart supervisor when env vars change

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -34,6 +34,7 @@
         - install_galaxy
 
     - role: set_supervisor_env_vars
+      tags: env_vars
 
     #installs supervisor, nginx and proftpd
     - role: galaxyprojectdotorg.galaxy-extras

--- a/group_vars/all
+++ b/group_vars/all
@@ -29,7 +29,7 @@ shed_tools_dir: "{{ galaxy_server_dir }}/../shed_tools"
 tool_data_dir: "{{ galaxy_server_dir  }}/tool-data"
 additional_files_list: []
 supervisor_env_vars:
-    - export IP_ADDRESS=`curl icanhazip.com`
+    - export IP_ADDRESS=`curl --silent icanhazip.com`
     - export GALAXY_CONFIG_FTP_UPLOAD_SITE="ftp://$IP_ADDRESS"
     - export MASQUERADE_ADDRESS=$IP_ADDRESS
     - export NATIVE_SPEC="--ntasks=`/usr/bin/nproc` --share"

--- a/roles/set_supervisor_env_vars/defaults/main.yml
+++ b/roles/set_supervisor_env_vars/defaults/main.yml
@@ -1,5 +1,5 @@
 supervisor_env_vars:
-    - export IP_ADDRESS=`curl icanhazip.com`
+    - export IP_ADDRESS=`curl --silent icanhazip.com`
     - export GALAXY_CONFIG_FTP_UPLOAD_SITE="ftp://$IP_ADDRESS"
     - export MASQUERADE_ADDRESS=$IP_ADDRESS
     - export NATIVE_SPEC="--ntasks=`/usr/bin/nproc` --share"

--- a/roles/set_supervisor_env_vars/tasks/main.yml
+++ b/roles/set_supervisor_env_vars/tasks/main.yml
@@ -1,8 +1,17 @@
 # Some environmental variables need to be set before supervisor starts.
 # This can be done by adding lines in /etc/default/supervisor,
 # which will be sourced when starting/restarting supervisor
+# If we change these we need to restart supervisor
+
+- name: Install supervisor
+  apt: name="supervisor" state="present"
 
 - name: Add supervisor ENV vars
   lineinfile: "dest=/etc/default/supervisor state=present create=yes line={{ item }}"
   with_items:
     - "{{ supervisor_env_vars }}"
+  register: env_var_task
+
+- name: restart supervisor
+  service: name=supervisor state=restarted
+  when: env_var_task.changed


### PR DESCRIPTION
We need to restart supervisor whenever environmental variables change.
Also make curl output silent. Closes #133.

I hope this will make upgrading older instances bullet-proof.