### PR TITLE
Make nat_masquerade configurable in docker and test with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ before_install:
   - export GALAXY_USER_PASSWD=admin
   - export BIOBLEND_GALAXY_API_KEY=admin
   - export BIOBLEND_GALAXY_URL=http://localhost:8080
-
   - docker --version
   - docker info
 
@@ -32,6 +31,7 @@ before_install:
   - sudo chown -R $GALAXY_TRAVIS_USER:$GALAXY_TRAVIS_USER $GALAXY_HOME
   - docker build -t galaxy_kickstart .
   - sudo mkdir /export && sudo chown $GALAXY_UID:$GALAXY_GID /export
+  - MASQ=`docker run -d -e NAT_MASQUERADE=true galaxy_kickstart`
   - |
     docker run -d -p 8080:80 -p 8021:21 -p 8800:8800 \
     --privileged=true \
@@ -68,6 +68,8 @@ script:
   - curl --fail $BIOBLEND_GALAXY_URL/api/version
   - time > $HOME/time.txt && curl --fail -T $HOME/time.txt ftp://localhost:8021 --user $GALAXY_USER:$GALAXY_USER_PASSWD
   - curl --fail ftp://localhost:8021 --user $GALAXY_USER:$GALAXY_USER_PASSWD
+  # test that proftpd is running when nat_masquerade=true
+  - docker exec -it $MASQ supervisorctl status | grep proftpd | grep RUNNING
   # Change back to $TRAVIS_BUILD_DIR, since deployment will fail otherwise
   - cd $TRAVIS_BUILD_DIR
 deploy:

--- a/dockerfiles/galaxy-kickstart/Dockerfile
+++ b/dockerfiles/galaxy-kickstart/Dockerfile
@@ -33,7 +33,8 @@ RUN mkdir /etc/ssl/private-copy; mv /etc/ssl/private/* /etc/ssl/private-copy/; r
 
 
 ENV NGINX_GALAXY_LOCATION="" \
-GALAXY_CONFIG_ADMIN_USERS="admin@galaxy.org"
+GALAXY_CONFIG_ADMIN_USERS="admin@galaxy.org" \
+NAT_MASQUERADE=false
 
 ONBUILD  WORKDIR  /setup
 ONBUILD  COPY  .  /setup
@@ -50,5 +51,6 @@ CMD printenv >> /etc/default/supervisor && bash -c "source /etc/default/supervis
            --extra-vars nginx_galaxy_location=$NGINX_GALAXY_LOCATION \
            --extra-vars galaxy_admin=$GALAXY_CONFIG_ADMIN_USERS \
            --extra-vars ftp_upload_site=$IP_ADDRESS \
+           --extra-vars nat_masquerade=$NAT_MAQUERADE \
            -i docker_inventory && \
            /usr/bin/python /usr/bin/supervisord -c /etc/supervisor/supervisord.conf --nodaemon"


### PR DESCRIPTION
... that the supervisorctl status is RUNNING. We can't test the FTP directly,
since the IP in travis is not publicly available for incoming packages.

Closes #131 