### PR TITLE
Use correct metavisitor inventory

### DIFF
--- a/dockerfiles/galaxy-kickstart-metavisitor/Dockerfile
+++ b/dockerfiles/galaxy-kickstart-metavisitor/Dockerfile
@@ -20,5 +20,5 @@ CMD printenv >> /etc/default/supervisor && bash -c "source /etc/default/supervis
            --extra-vars nginx_galaxy_location=$NGINX_GALAXY_LOCATION \
            --extra-vars galaxy_admin=$GALAXY_CONFIG_ADMIN_USERS \
            --extra-vars ftp_upload_site=$IP_ADDRESS \
-           -i docker_inventory && \
+           -i docker_metavisitor_inventory && \
            /usr/bin/python /usr/bin/supervisord -c /etc/supervisor/supervisord.conf --nodaemon"


### PR DESCRIPTION
when running the docker container.

Should restore the homepage for the metavisitor docker image.
For #140 