### PR TITLE
Restructure playbook to only restart galaxy when necessary

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -36,6 +36,10 @@
     - role: set_supervisor_env_vars
       tags: env_vars
 
+    - role: copy_additional_files
+      tags:
+        - install_extras
+
     #installs supervisor, nginx and proftpd
     - role: galaxyprojectdotorg.galaxy-extras
       tags:
@@ -52,7 +56,7 @@
       run_extras: true
       pbkdf2: true
       create_galaxy_admin: true
-      restart_galaxy: true
+      restart_galaxy: false
       tags:
         - install_extras
       
@@ -64,19 +68,11 @@
       sudo: yes
       sudo_user: "{{ galaxy_user_name }}"
       tags: install_tools
-      when: install_tools
 
-    - role: galaxyprojectdotorg.galaxy-tools
-      sudo: yes
-      sudo_user: "{{ galaxy_user_name }}"
-      tags: install_tools
-      galaxy_tools_tool_list: "{{ galaxy_data_manager_tool_list }}"
-      when: run_data_manager
-
-    #Restart Galaxy
+    # Restart Galaxy if tools have been installed
     - role: artimed_extras
       restart_galaxy: true
-      when: install_tools or run_data_manager
+      when: galaxy_tools_tool_list_files|length > 0
 
     - role: artimed_extras
       run_data_managers: true

--- a/roles/artimed_extras/tasks/extras.yml
+++ b/roles/artimed_extras/tasks/extras.yml
@@ -12,11 +12,6 @@
 - name: Create tool dependency dir
   file: path="{{ tool_dependency_dir}}" state=directory owner={{ galaxy_user_name}} group={{ galaxy_user_name }}
 
-- name:  Copy additional files
-  copy: src={{ item.src }} dest={{ item.dest }} owner={{ galaxy_user_name }}
-  with_items:
-    - "{{ additional_files_list }}"
-    
 - name: Restart/start supervisor tasks
   supervisorctl: name={{ item.name }} state={{ item.state }}
   with_items:

--- a/roles/copy_additional_files/defaults/main.yml
+++ b/roles/copy_additional_files/defaults/main.yml
@@ -1,0 +1,2 @@
+galaxy_user_name: galaxy
+additional_files_list: []

--- a/roles/copy_additional_files/tasks/main.yml
+++ b/roles/copy_additional_files/tasks/main.yml
@@ -1,0 +1,4 @@
+- name:  Copy additional files
+  copy: src={{ item.src }} dest={{ item.dest }} owner={{ galaxy_user_name }}
+  with_items:
+    - "{{ additional_files_list }}"


### PR DESCRIPTION
This includes extracting the copy_additional_files role, which may modify the
tool_sheds_conf.xml file, after which a restart of galaxy is required.  We
therefore put this new role before galaxy_extras, which at its end already
restarts galaxys. If we don't install any tools, we also don't restart galaxy
at the end of the run. This should accelerate tests and image building.